### PR TITLE
Update README links to point to `master`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ end
 
 Then run `pod install`.
 
-Now ABIEOS Serialization Provider is ready for use within EOSIO SDK for Swift according to the [EOSIO SDK for Swift Basic Usage instructions](https://github.com/EOSIO/eosio-swift/tree/develop#basic-usage).
+Now ABIEOS Serialization Provider is ready for use within EOSIO SDK for Swift according to the [EOSIO SDK for Swift Basic Usage instructions](https://github.com/EOSIO/eosio-swift/tree/master#basic-usage).
 
 ## Direct Usage
 


### PR DESCRIPTION
README links to other EOSIO Swift repos should point to `master`.